### PR TITLE
Add global command cooldown system

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -21,6 +21,7 @@ import logging
 from datetime import datetime, timezone
 from dotenv import load_dotenv
 from utils import database
+from utils.cooldowns import GlobalCommandCooldown
 
 # Setup logging
 logging.basicConfig(
@@ -90,7 +91,7 @@ class MikuBot(commands.Bot):
             'cogs.utilities',
             'cogs.fun',
             'cogs.info',
-            'cogs.command_handler',  # 👈 added global cooldown handler
+            'cogs.command_handler',  # 👈 global cooldown handler
         ]
         
         for cog in cogs:
@@ -117,15 +118,32 @@ class MikuBot(commands.Bot):
     async def on_command_error(self, ctx: commands.Context, error: commands.CommandError) -> None:
         """Global command error handler.
 
-        We intentionally ignore unknown commands so random messages like
-        `&rewards` don't spam the console.
+        This is the single, central place cooldown (and other command)
+        errors get turned into user-facing messages. Cogs should NOT also
+        register their own on_command_error listeners for the same errors,
+        or the error gets handled twice.
         """
         # Ignore unknown commands completely.
         if isinstance(error, commands.CommandNotFound):
             return
 
-        # If a command defines its own error handler, don't double-handle.
+        # If a command defines its own local error handler, don't double-handle.
         if ctx.command is not None and ctx.command.has_error_handler():
+            return
+
+        # Our global per-command cooldown system (cogs/command_handler.py).
+        if isinstance(error, GlobalCommandCooldown):
+            await ctx.send(
+                f"⏳ Slow down! Try `{ctx.command.qualified_name}` again in {error.retry_after:.1f}s."
+            )
+            return
+
+        # discord.py's own built-in cooldown (in case any command still uses
+        # @commands.cooldown directly instead of the global system).
+        if isinstance(error, commands.CommandOnCooldown):
+            await ctx.send(
+                f"⏳ Slow down! Try `{ctx.command.qualified_name}` again in {error.retry_after:.1f}s."
+            )
             return
 
         # For everything else, fall back to default logging/behavior.

--- a/src/bot.py
+++ b/src/bot.py
@@ -90,6 +90,7 @@ class MikuBot(commands.Bot):
             'cogs.utilities',
             'cogs.fun',
             'cogs.info',
+            'cogs.command_handler',  # 👈 added global cooldown handler
         ]
         
         for cog in cogs:

--- a/src/cogs/command_handler.py
+++ b/src/cogs/command_handler.py
@@ -1,0 +1,29 @@
+"""Global command cooldown system.
+
+Applies a per-user, per-command cooldown to every command in the bot via a
+global check (bot.add_check), so individual commands don't need to opt in
+with their own @commands.cooldown decorator.
+"""
+
+from discord.ext import commands
+
+from utils.cooldowns import cooldown_manager, CommandOnCooldown
+
+
+class CommandHandler(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        bot.add_check(self.global_cooldown_check)
+
+    async def global_cooldown_check(self, ctx: commands.Context) -> bool:
+        if ctx.command is None:
+            return True
+
+        retry_after = cooldown_manager.check(ctx.author.id, ctx.command.qualified_name)
+        if retry_after > 0:
+            raise CommandOnCooldown(retry_after)
+        return True
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(CommandHandler(bot))

--- a/src/cogs/command_handler.py
+++ b/src/cogs/command_handler.py
@@ -7,7 +7,7 @@ with their own @commands.cooldown decorator.
 
 from discord.ext import commands
 
-from utils.cooldowns import cooldown_manager, CommandOnCooldown
+from utils.cooldowns import cooldown_manager, GlobalCommandCooldown
 
 
 class CommandHandler(commands.Cog):
@@ -21,7 +21,7 @@ class CommandHandler(commands.Cog):
 
         retry_after = cooldown_manager.check(ctx.author.id, ctx.command.qualified_name)
         if retry_after > 0:
-            raise CommandOnCooldown(retry_after)
+            raise GlobalCommandCooldown(retry_after)
         return True
 
 

--- a/src/cogs/utilities.py
+++ b/src/cogs/utilities.py
@@ -90,7 +90,6 @@ class Utilities(commands.Cog):
     # =====================================================================
 
     @commands.hybrid_command(name="ping", description="Check if the bot is responsive")
-    @commands.cooldown(rate=1, per=5.0, type=commands.BucketType.user)
     async def ping(self, ctx: commands.Context) -> None:
         """Show bot latency."""
         latency_ms = round(getattr(self.bot, "latency", 0.0) * 1000)
@@ -300,16 +299,6 @@ class Utilities(commands.Cog):
         embed.add_field(name="Voice Channels", value=str(len(guild.voice_channels)), inline=True)
 
         await self._send(ctx, embed=embed)
-
-    @commands.Cog.listener()
-    async def on_command_error(self, ctx: commands.Context, error: commands.CommandError) -> None:
-        if isinstance(error, commands.CommandOnCooldown):
-            await ctx.send(
-                f"⏳ Slow down! Try `{ctx.command.name}` again in {error.retry_after:.1f}s.",
-                ephemeral=True if getattr(ctx, "interaction", None) else False,
-            )
-            return
-        raise error
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/src/cogs/utilities.py
+++ b/src/cogs/utilities.py
@@ -90,6 +90,7 @@ class Utilities(commands.Cog):
     # =====================================================================
 
     @commands.hybrid_command(name="ping", description="Check if the bot is responsive")
+    @commands.cooldown(rate=1, per=5.0, type=commands.BucketType.user)
     async def ping(self, ctx: commands.Context) -> None:
         """Show bot latency."""
         latency_ms = round(getattr(self.bot, "latency", 0.0) * 1000)
@@ -299,6 +300,16 @@ class Utilities(commands.Cog):
         embed.add_field(name="Voice Channels", value=str(len(guild.voice_channels)), inline=True)
 
         await self._send(ctx, embed=embed)
+
+    @commands.Cog.listener()
+    async def on_command_error(self, ctx: commands.Context, error: commands.CommandError) -> None:
+        if isinstance(error, commands.CommandOnCooldown):
+            await ctx.send(
+                f"⏳ Slow down! Try `{ctx.command.name}` again in {error.retry_after:.1f}s.",
+                ephemeral=True if getattr(ctx, "interaction", None) else False,
+            )
+            return
+        raise error
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/src/utils/cooldowns.py
+++ b/src/utils/cooldowns.py
@@ -1,0 +1,38 @@
+import time
+
+from discord.ext import commands
+
+
+class CommandOnCooldown(commands.CommandError):
+    """Raised when a user tries to run a command while it's on cooldown."""
+
+    def __init__(self, retry_after: float):
+        self.retry_after = retry_after
+        super().__init__(f"Command on cooldown. Retry in {retry_after:.1f}s")
+
+
+class CooldownManager:
+    def __init__(self, cooldown_seconds: float = 5):
+        self.cooldown_seconds = cooldown_seconds
+        self.user_timestamps: dict[tuple[int, str], float] = {}
+
+    def check(self, user_id: int, command_name: str) -> float:
+        """Return seconds remaining on cooldown (0 if not on cooldown).
+
+        If the user is NOT on cooldown, this also records the current time
+        as their new "last used" timestamp for this command.
+        """
+        now = time.time()
+        key = (user_id, command_name)
+        last_used = self.user_timestamps.get(key, 0.0)
+        elapsed = now - last_used
+
+        if elapsed < self.cooldown_seconds:
+            return self.cooldown_seconds - elapsed
+
+        self.user_timestamps[key] = now
+        return 0.0
+
+
+# Global instance shared across all cogs.
+cooldown_manager = CooldownManager(cooldown_seconds=5)

--- a/src/utils/cooldowns.py
+++ b/src/utils/cooldowns.py
@@ -3,8 +3,12 @@ import time
 from discord.ext import commands
 
 
-class CommandOnCooldown(commands.CommandError):
-    """Raised when a user tries to run a command while it's on cooldown."""
+class GlobalCommandCooldown(commands.CommandError):
+    """Raised when a user tries to run a command while it's on cooldown.
+
+    Named distinctly from discord.py's own commands.CommandOnCooldown to
+    avoid isinstance-check collisions in error handlers.
+    """
 
     def __init__(self, retry_after: float):
         self.retry_after = retry_after


### PR DESCRIPTION
## What changed?
Added a global cooldown system that applies to every command automatically. Previously, cooldown checks were implemented as an event listener, which could not actually block a command from running — users could still spam commands and get multiple replies. This replaces that with a proper global check (`bot.add_check`) that runs before a command executes, so spammed commands are genuinely blocked and the user gets a message showing how long they need to wait.

## Why?
Closes #22

## How to test
1. Run the bot: `python src/bot.py`
2. In a Discord server the bot is in, spam a command quickly, e.g. `&ping` three times in a row.
   - Expected: first call replies normally ("Pong! Latency: XXXms").
   - Expected: subsequent calls within 5 seconds reply "⏳ Slow down! Try `ping` again in X.Xs."
3. Wait 5+ seconds, run `&ping` again — should reply normally.
4. Try a different command, e.g. `&uptime`, right after a successful `&ping` — should also work and independently respect its own cooldown if spammed.

## Checklist
- [x] I linked an issue or explained why not (Closes #22)
- [x] I added/updated tests (or explained why not) — no automated test suite exists in this repo yet; verified manually in a live Discord test server (see screenshots)
- [x] I did not commit secrets (tokens, `.env`, keys)
- [ ] I added/updated docs for user-facing changes (no docs currently exist for this bot; happy to add if maintainers want)
- [x] CI should pass for this PR

## Screenshots
Cooldown blocking repeated `&ping` spam, then succeeding after the cooldown window passes:
<img width="523" height="643" alt="image" src="https://github.com/user-attachments/assets/9c57300c-1e55-44ff-b97e-cffe3ea4071f" />
